### PR TITLE
added coding comment

### DIFF
--- a/lib/ext/number_helper.rb
+++ b/lib/ext/number_helper.rb
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 ActionView::Helpers::NumberHelper.module_eval do
   def number_to_currency_with_synergy(number, options = {})
     number_to_currency_without_synergy(number, options).gsub(' ', "\302\240")


### PR DESCRIPTION
в Ruby 1.9.2 p180 без magic комментария появляется ошибка
Incompatible character encodings: UTF-8 and ASCII-8BIT
