### PR TITLE
Исправление ошибки описанной в Issue #21

### DIFF
--- a/lib/synergy.rb
+++ b/lib/synergy.rb
@@ -85,8 +85,7 @@ module Synergy
           Calculator::CashOnDelivery,
           Calculator::Juridical,
           Calculator::FlexiRate,
-          Calculator::PerItem,
-          Calculator::PriceBucket]
+          Calculator::PerItem]
     end
     
     initializer "spree.register.payment_methods" do |app|


### PR DESCRIPTION
Исправление ошибки описанной в #21 при попытке обновления spree до 0.70 версии "uninitialized constant Calculator::PriceBucket (NameError)"
